### PR TITLE
Remove batch size limits on catalog queries

### DIFF
--- a/Products/Maps/adapters.py
+++ b/Products/Maps/adapters.py
@@ -33,21 +33,21 @@ class SmartFolderMap(BaseMap):
     adapts(IATTopic)
 
     def _getItems(self):
-        return self.context.queryCatalog()
+        return self.context.queryCatalog(b_size=0)
 
 if ICollection:
     class CollectionMap(BaseMap):
         adapts(ICollection)
-    
+
         def _getItems(self):
-            return self.context.queryCatalog()
+            return self.context.queryCatalog(b_size=0)
 
 
 class FolderMap(BaseMap):
     adapts(IATFolder)
 
     def _getItems(self):
-        return self.context.getFolderContents()
+        return self.context.getFolderContents(b_size=0)
 
 
 class GeoLocation(object):

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,7 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Where the catalog is queried, we were inheriting implicit batch size limitations that are not useful in this context. Fixed. [smcmahon]
 - Added back default location [sithmel]
 - Removed some inline styling for better customization [sithmel]
 - when you changed layers the search was not updated (fixed) [sithmel]
@@ -24,7 +25,7 @@ Changelog
 
 - Store map objects in window.activeMaps to allow end-develops access
   [StevenLooman]
-- added title in popup window [giacomos]  
+- added title in popup window [giacomos]
 
 
 3.2 (2013-03-14)


### PR DESCRIPTION
Maps were cut off at 30 pointers/labels due to a batch-size limit. Fixed.